### PR TITLE
Fix pinned locations not always being visible.

### DIFF
--- a/ootrando_overworldmap_hamsda/layouts/layouts.json
+++ b/ootrando_overworldmap_hamsda/layouts/layouts.json
@@ -33,6 +33,25 @@
         },
         {
           "type": "dock",
+          "dock": "bottom",
+          "content": [
+            {
+              "type": "group",
+              "header": "Pinned Locations",
+              "content": {
+                "type": "recentpins",
+                "style": "wrap",
+                "h_alignment": "stretch",
+                "v_alignment": "stretch",
+                "orientation": "horizontal",
+                "compact": true
+              }
+            }
+          ]
+        },
+        {
+          "type": "dock",
+          "dock": "top",
           "content": [
             {
               "type": "tabbed",
@@ -69,18 +88,6 @@
                   }
                 }
               ]
-            },
-            {
-              "type": "group",
-              "header": "Pinned Locations",
-              "content": {
-                "type": "recentpins",
-                "style": "wrap",
-                "h_alignment": "stretch",
-                "v_alignment": "stretch",
-                "orientation": "horizontal",
-                "compact": true
-              }
             }
           ]
         }


### PR DESCRIPTION
The 'Pinned Locations' tab is not always visible (if the map doesn't fit the screen). This change ensures that 'Pinned Locations' always gets as much space as it needs for it to be shown on-screen.